### PR TITLE
Bump action to Node v24

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set Node.js 20.x
+      - name: Set Node.js 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24.x
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set Node.js 24.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         terragrunt_version: [0.35.8, latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup terragrunt
         uses: ./

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: ${{ github.token }}
 runs:
-  using: node20
+  using: node24
   main: dist/index.js
 branding:
   icon: "terminal"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-terragrunt",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-terragrunt",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-terragrunt",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Setup Terragrunt CLI for GitHub Actions",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
[Node 20 runners are being deprecated by GHA this year](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

Similar to what was done in #1 for Node 20, this bumps the action to use Node 24. 

Note that because #6 never got tagged in a release, it's also going to come with in a `1.0.4` release but I think that's fine 
```
$ git log --oneline --decorate=short upstream/main -5
e49c7c7 (upstream/main, upstream/HEAD, origin/main, origin/HEAD, main) Merge pull request #6 from eLco/dependabot/npm_and_yarn/braces-3.0.3
d29a7d5 Bump braces from 3.0.2 to 3.0.3
2c5116f (tag: v1.0.3, tag: v1) Merge pull request #2 from eLco/dependabot/npm_and_yarn/json5-2.2.3
075d86f Merge pull request #4 from eLco/dependabot/npm_and_yarn/babel/traverse-7.24.1
f7fb1d3 Merge pull request #5 from eLco/nodejs20
```